### PR TITLE
Move token to token.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 CURRENT BUILD/cache.json
 CURRENT BUILD/titlecache.json
 CURRENT BUILD/__pycache__
+CURRENT BUILD/token.yml

--- a/CURRENT BUILD/bot.py
+++ b/CURRENT BUILD/bot.py
@@ -15,6 +15,7 @@ import time
 import os
 from functions import *
 import importlib
+import pyyaml
 #commands
 client = commands.Bot(command_prefix="!")
 client.remove_command('help')
@@ -25,6 +26,8 @@ chrome_options.add_extension(os.path.abspath('extension_1_32_4_0.crx'))
 plugins={}
 #load driver
 driver = webdriver.Chrome(options=chrome_options)
+#load token
+token = yaml.safe_load(open('token.yml'))
 
 for file in os.listdir(os.getcwd()+r"\\plugins"):
     if file.endswith(".py"):
@@ -172,4 +175,4 @@ async def grab(ctx):
                     
 
 
-client.run('token goes here')#token to be entered 
+client.run(token["token"])

--- a/CURRENT BUILD/token.yml
+++ b/CURRENT BUILD/token.yml
@@ -1,0 +1,1 @@
+token: "insert token here"


### PR DESCRIPTION
Makes it easier to setup and harder to accidentally leak the token.
Adds pyyaml as a dependency, since I'm not a big fan of handling json in python.
The same principle could be used for future expansion with configuration, even in the same file.
Make sure to test it since I can't test it on linux